### PR TITLE
Add arguments of commands to Settings & Commands docs.

### DIFF
--- a/client/commands.py
+++ b/client/commands.py
@@ -4,7 +4,7 @@ import sys
 import re
 
 print '<table class="settingscommands">'
-print '  <tr><th>Command</th><th>Description</th></tr>'
+print '  <tr><th>Command</th><th>Arguments</th><th>Description</th></tr>'
 
 for line in sys.stdin:
   if sys.argv[1] not in line:
@@ -13,8 +13,8 @@ for line in sys.stdin:
   x = re.findall(r'(?:[^\s,"]|"(?:\\.|[^"])*")+', line)
   y = line.split('"')
 
-  result = (y[1], y[-2])
+  result = (y[1], y[3], y[-2])
 
-  print '  <tr><td>%s</td><td>%s</td></tr>' % result
+  print '  <tr><td>%s</td><td>%s</td><td>%s</td></tr>' % result
 
 print '</table>'


### PR DESCRIPTION
Adds another column to https://ddnet.tw/settingscommands/ for commands which displays the usage string (for the ban command it looks like this: `s[ip|id] ?i[minutes] r[reason]`). Not exactly beautiful but probably useful.