### PR TITLE
Update deprecated --gecos

### DIFF
--- a/ddnet-setup.sh
+++ b/ddnet-setup.sh
@@ -28,7 +28,7 @@ pip3 install sqlite3-to-mysql --upgrade --break-system-packages || pip3 install 
 
 hostnamectl set-hostname ddnet$NAME_LOWER
 addgroup teeworlds
-adduser --gecos "" --home /home/teeworlds --shell /usr/bin/zsh --disabled-password --ingroup users teeworlds
+adduser --comment "" --home /home/teeworlds --shell /usr/bin/zsh --disabled-password --ingroup users teeworlds
 sed -E -i "s/^#?Port .*/Port 6546/" /etc/ssh/sshd_config
 sed -E -i "s/^#?PermitRootLogin .*/PermitRootLogin yes/" /etc/ssh/sshd_config
 systemctl restart ssh


### PR DESCRIPTION
From the man page

```
       --comment comment
              Set  the comment field for the new entry generated.  adduser will not ask for the information if this option is given.  This field is also known under the name GECOS field and contains infor‐
              mation that is used by the finger(1) command.  This used to be the --gecos option, which is deprecated and will be removed after Debian bookworm.  Valid Modes: adduser, adduser --system.
```