### PR TITLE
Enable compression for the master replica

### DIFF
--- a/master-replica-setup.md
+++ b/master-replica-setup.md
@@ -46,6 +46,7 @@ Make sure port 443 isn't blocked by a firewall. Install `caddy`. `mkdir -p
 ```
 master2.ddnet.org:443 {
 	root * /var/www-master2
+	encode zstd gzip
 	file_server {
 		browse
 	}


### PR DESCRIPTION
This is important because it reduces the download size by a factor of 6.