### PR TITLE
Only delete doxygen output from `docs` folder for codedoc deploy

### DIFF
--- a/release/build-and-deploy.sh
+++ b/release/build-and-deploy.sh
@@ -37,10 +37,12 @@ if [ "$1" = "nightly" ]; then
   rsync -avP --delay-updates --delete-delay codebrowser ddnet:/var/www/
   rm -rf codebrowser
   cd ddnet-source
-  rm -rf docs
+  rm -rf docs/html
+  rm -rf docs/warn.log
   doxygen -q
   rsync -avP --delay-updates --delete-delay docs/html/ ddnet:/var/www-codedoc/
-  rm -rf docs
+  rm -rf docs/html
+  rm -rf docs/warn.log
   cd ..
 elif [ "$1" = "playground" ]; then
   export UPDATE_FLAGS="-DAUTOUPDATE=OFF -DINFORM_UPDATE=OFF"


### PR DESCRIPTION
After ddnet/ddnet#11697 splits up the documentation into multiple files within the `docs` folder, we might want to add some files from within the `docs` folder to the generated documentation, so we shouldn't delete the entire folder before invoking doxygen.